### PR TITLE
Add iptables kill switch + IPv6 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get install -y \
     tzdata dnsutils iputils-ping ufw iproute2 \
     openssh-client git jq curl wget unrar unzip bc \
     # New for this image
-    wireguard nginx \
+    wireguard nginx iptables \
     # End new for this image
     && rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/* \
     && useradd -u 911 -U -d /config -s /bin/false abc \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk --no-cache add curl jq \
     && wget -qO- https://github.com/killemov/Shift/archive/master.tar.gz | tar xz -C /opt/transmission-ui \
     && mv /opt/transmission-ui/Shift-master /opt/transmission-ui/shift \
     && echo "Install Flood for Transmission" \
-    && wget -qO- https://github.com/johman10/flood-for-transmission/releases/download/latest/flood-for-transmission.tar.gz | tar xz -C /opt/transmission-ui \
+    && wget -qO- https://github.com/johman10/flood-for-transmission/releases/latest/download/flood-for-transmission.tar.gz | tar xz -C /opt/transmission-ui \
     && echo "Install Combustion" \
     && wget -qO- https://github.com/Secretmapper/combustion/archive/release.tar.gz | tar xz -C /opt/transmission-ui \
     && echo "Install kettu" \

--- a/start.sh
+++ b/start.sh
@@ -29,10 +29,15 @@ echo "Gateway: $GW"
 echo "Interface address: $INT_IP"
 echo "Interface broadcast: $INT_BRD"
 
-# Override DNS to Cloudflare unless SKIP_DNS_OVERRIDE is set to true (case insensitive)
+# Override DNS to Cloudflare (IPv4 + IPv6) unless SKIP_DNS_OVERRIDE is set to true (case insensitive)
 if [ -z "${SKIP_DNS_OVERRIDE}" ] || ! [[ "${SKIP_DNS_OVERRIDE,,}" == "true" ]]; then
-  echo "Overriding DNS to Cloudflare"
-  echo "nameserver 1.1.1.1" > /etc/resolv.conf
+  echo "Overriding DNS to Cloudflare (IPv4 + IPv6)"
+  cat > /etc/resolv.conf << EOF
+nameserver 1.1.1.1
+nameserver 1.0.0.1
+nameserver 2606:4700:4700::1111
+nameserver 2606:4700:4700::1001
+EOF
 else
   echo "Skipping DNS override due to SKIP_DNS_OVERRIDE=${SKIP_DNS_OVERRIDE}"
 fi
@@ -60,10 +65,22 @@ ip -n physical route add default via "$GW" dev "$INT"
 # We need to make the wg0 interface separately to do the namespace linking
 # and we can't use wg-quick after that. So the rest is done "manually".
 #
-address=$(grep "Address" "$CONFIG_FILE" | awk '{print $NF}' | cut -d, -f1)
-#dns=$(grep "DNS" "$config_file" | awk '{print $NF}')
 
-ip addr add "$address" dev wg0
+# Extract IPv4 and IPv6 addresses from WireGuard config
+# Config format: Address = 10.x.x.x/32, fd00::x/128
+ipv4_address=$(grep "Address" "$CONFIG_FILE" | awk '{print $NF}' | tr ',' '\n' | grep -E '^[0-9]+\.' | head -1)
+ipv6_address=$(grep "Address" "$CONFIG_FILE" | awk '{print $NF}' | tr ',' '\n' | grep -E '^[a-fA-F0-9:]+/' | head -1)
+
+echo "WireGuard IPv4 address: $ipv4_address"
+echo "WireGuard IPv6 address: ${ipv6_address:-none}"
+
+ip addr add "$ipv4_address" dev wg0
+
+# Add IPv6 if present in config
+if [ -n "$ipv6_address" ]; then
+  echo "Adding IPv6 address: $ipv6_address"
+  ip -6 addr add "$ipv6_address" dev wg0
+fi
 
 stripped_config_file=$(mktemp)
 wg-quick strip "$CONFIG_FILE" > "$stripped_config_file"
@@ -74,11 +91,147 @@ ip link set wg0 up
 #ip link set lo up
 ip route add default dev wg0
 
+# Add IPv6 default route if IPv6 is configured
+if [ -n "$ipv6_address" ]; then
+  echo "Adding IPv6 default route via wg0"
+  ip -6 route add default dev wg0
+fi
+
 #
 # Wireguard interface is now set up and should be connected
 #
 echo "Wireguard is up - new IP:"
 curl --silent -w "\n" ipecho.net/plain
+
+#
+# Set up iptables kill switch to prevent IP leaks
+#
+setup_killswitch() {
+  echo "Setting up iptables kill switch..."
+
+  # Get WireGuard server endpoint for allowed exception
+  wg_endpoint=$(wg show wg0 endpoints | awk '{print $2}' | cut -d: -f1)
+  wg_port=$(wg show wg0 endpoints | awk '{print $2}' | cut -d: -f2)
+
+  if [ -z "$wg_endpoint" ] || [ -z "$wg_port" ]; then
+    echo "ERROR: Failed to get WireGuard endpoint. Cannot configure kill switch safely."
+    exit 1
+  fi
+
+  echo "WireGuard endpoint: $wg_endpoint:$wg_port"
+
+  #
+  # IPv4 Rules
+  #
+
+  # Flush existing rules
+  iptables -F OUTPUT
+  iptables -F INPUT
+
+  # Default policy: DROP all outbound traffic
+  iptables -P OUTPUT DROP
+  iptables -P INPUT DROP
+  iptables -P FORWARD DROP
+
+  # Allow loopback
+  iptables -A OUTPUT -o lo -j ACCEPT
+  iptables -A INPUT -i lo -j ACCEPT
+
+  # Allow all traffic through WireGuard interface
+  iptables -A OUTPUT -o wg0 -j ACCEPT
+  iptables -A INPUT -i wg0 -j ACCEPT
+
+  # Allow ICMP for diagnostics and Path MTU Discovery (through wg0 only)
+  iptables -A OUTPUT -o wg0 -p icmp --icmp-type echo-request -j ACCEPT
+  iptables -A INPUT -i wg0 -p icmp --icmp-type echo-reply -j ACCEPT
+  iptables -A INPUT -i wg0 -p icmp --icmp-type destination-unreachable -j ACCEPT
+
+  # Allow traffic through veth1 to physical namespace (for nginx proxy)
+  iptables -A OUTPUT -o veth1 -d 10.10.13.37/31 -j ACCEPT
+  iptables -A INPUT -i veth1 -s 10.10.13.37/31 -j ACCEPT
+
+  # Allow established/related connections
+  iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+  iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
+  #
+  # IPv6 Rules
+  #
+
+  # Flush existing rules
+  ip6tables -F OUTPUT
+  ip6tables -F INPUT
+
+  # Default policy: DROP all IPv6 traffic
+  ip6tables -P OUTPUT DROP
+  ip6tables -P INPUT DROP
+  ip6tables -P FORWARD DROP
+
+  # Allow loopback
+  ip6tables -A OUTPUT -o lo -j ACCEPT
+  ip6tables -A INPUT -i lo -j ACCEPT
+
+  # If IPv6 is configured on WireGuard, allow it
+  if [ -n "$ipv6_address" ]; then
+    ip6tables -A OUTPUT -o wg0 -j ACCEPT
+    ip6tables -A INPUT -i wg0 -j ACCEPT
+
+    # Allow ICMPv6 for diagnostics and Path MTU Discovery
+    ip6tables -A OUTPUT -o wg0 -p icmpv6 --icmpv6-type echo-request -j ACCEPT
+    ip6tables -A INPUT -i wg0 -p icmpv6 --icmpv6-type echo-reply -j ACCEPT
+    ip6tables -A INPUT -i wg0 -p icmpv6 --icmpv6-type packet-too-big -j ACCEPT
+  fi
+
+  # Allow established/related connections
+  ip6tables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+  ip6tables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
+  echo "Kill switch configured - all traffic blocked except through wg0"
+}
+
+setup_physical_namespace_firewall() {
+  echo "Setting up physical namespace firewall..."
+
+  # Get WireGuard endpoint
+  wg_endpoint=$(wg show wg0 endpoints | awk '{print $2}' | cut -d: -f1)
+  wg_port=$(wg show wg0 endpoints | awk '{print $2}' | cut -d: -f2)
+
+  if [ -z "$wg_endpoint" ] || [ -z "$wg_port" ]; then
+    echo "ERROR: Failed to get WireGuard endpoint. Cannot configure physical namespace firewall safely."
+    exit 1
+  fi
+
+  # Default policies in physical namespace
+  ip netns exec physical iptables -P OUTPUT DROP
+  ip netns exec physical iptables -P INPUT DROP
+  ip netns exec physical iptables -P FORWARD DROP
+
+  # Allow loopback
+  ip netns exec physical iptables -A OUTPUT -o lo -j ACCEPT
+  ip netns exec physical iptables -A INPUT -i lo -j ACCEPT
+
+  # Allow incoming connections to nginx reverse proxy
+  ip netns exec physical iptables -A INPUT -i "$INT" -p tcp --dport "${WEBPROXY_PORT:-9091}" -j ACCEPT
+
+  # Allow WireGuard UDP to endpoint
+  ip netns exec physical iptables -A OUTPUT -o "$INT" -d "$wg_endpoint" -p udp --dport "$wg_port" -j ACCEPT
+  ip netns exec physical iptables -A INPUT -i "$INT" -s "$wg_endpoint" -p udp --sport "$wg_port" -j ACCEPT
+
+  # Allow veth2 traffic (from default namespace via nginx proxy)
+  ip netns exec physical iptables -A INPUT -i veth2 -s 10.10.13.36/31 -j ACCEPT
+  ip netns exec physical iptables -A OUTPUT -o veth2 -d 10.10.13.36/31 -j ACCEPT
+
+  # Allow established connections
+  ip netns exec physical iptables -A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+  ip netns exec physical iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
+  # IPv6: Block everything in physical namespace
+  ip netns exec physical ip6tables -P OUTPUT DROP
+  ip netns exec physical ip6tables -P INPUT DROP
+  ip netns exec physical ip6tables -P FORWARD DROP
+
+  echo "Physical namespace firewall configured"
+}
 
 # Create a veth link pair, one interface in each namespace
 ip link add veth1 type veth peer name veth2 netns physical
@@ -91,7 +244,16 @@ ip -n physical addr add 10.10.13.37/31 dev veth2
 ip link set veth1 up
 ip -n physical link set veth2 up
 
-# Start a reverse proxy in the physical namespace
+# Apply kill switch rules (now veth1 exists)
+setup_killswitch
+
+# Apply physical namespace firewall rules
+setup_physical_namespace_firewall
+
+# Configure and start a reverse proxy in the physical namespace
+WEBPROXY_PORT="${WEBPROXY_PORT:-9091}"
+echo "Configuring nginx reverse proxy on port $WEBPROXY_PORT"
+sed -i "s/listen [0-9]*;/listen $WEBPROXY_PORT;/" /opt/nginx/server.conf
 ip netns exec physical nginx -c /opt/nginx/server.conf
 
 # Make sure TRANSMISSION_HOME exists and create/update settings.json

--- a/transmission-default-settings.json
+++ b/transmission-default-settings.json
@@ -7,7 +7,7 @@
     "alt-speed-time-end": 1020,
     "alt-speed-up": 50,
     "bind-address-ipv4": "0.0.0.0",
-    "bind-address-ipv6": "::",
+    "bind-address-ipv6": "",
     "blocklist-enabled": false,
     "blocklist-url": "http://www.example.com/blocklist",
     "cache-size-mb": 4,

--- a/transmission-default-settings.json
+++ b/transmission-default-settings.json
@@ -7,7 +7,7 @@
     "alt-speed-time-end": 1020,
     "alt-speed-up": 50,
     "bind-address-ipv4": "0.0.0.0",
-    "bind-address-ipv6": "",
+    "bind-address-ipv6": "::",
     "blocklist-enabled": false,
     "blocklist-url": "http://www.example.com/blocklist",
     "cache-size-mb": 4,


### PR DESCRIPTION
I needed these changes for my own setup and thought they could be useful for others as well. No pressure to merge this PR .. just sharing it in case others or the maintainer find the changes helpful :) Thanks for this project!

* iptables kill switch
Blocks all traffic except via wg0 to prevent IP leaks if the tunnel drops (traffic could fall back to eth0). Also this restricts the physical namespace to WireGuard endpoint traffic and the reverse proxy only. This requires the following capabilities in docker-compose:

```yaml
    cap_add:
      - NET_ADMIN
      - SYS_ADMIN
```

* IPv6 WireGuard support (IPv6 traffic was bypassing VPN)
Parse / Apply IPv6 addresses from the config. Also this adds the Cloudflare DNS to also include IPv6 resolvers.

* Configurable proxy port
I've created a WEBPROXY_PORT environment variable (defaults to 9091), which allows incoming connections to nginx.