### PR TITLE
Remove hardcoded "eth0" in start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -43,7 +43,7 @@ cat /etc/resolv.conf
 # Create a "physical" network namespace and move our eth0 there
 ip netns ls
 ip netns add physical
-ip link set eth0 netns physical
+ip link set "$INT" netns physical
 
 # Create wireguard interface in physical namespace and move it to the default namespace
 ip -n physical link add wg0 type wireguard


### PR DESCRIPTION
I was getting an error `Cannot find device "eth0"` in the logs trying to run this, and was confused because my machine doesn't have an interface `eth0`, it uses the newer scheme `enp1s0`. Turns out that although we're fetching the interface name correctly in start.sh:21
```sh
INT=$(/sbin/ip route list match 0.0.0.0 | awk '{print $5}')
```

line 46 hardcodes `eth0` instead of using `$INT`. This PR fixes that. I've tested the change locally, and the container now comes up and is functional!

Note: Unrelated to this issue, but it seems the link for Flood in the dockerfile is rotten, I had to comment it out to get the image to build