### PR TITLE
Modify start.sh so it works within K8S

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -21,7 +21,7 @@ fi
 GW=$(/sbin/ip route list match 0.0.0.0 | awk '{print $3}')
 INT=$(/sbin/ip route list match 0.0.0.0 | awk '{print $5}')
 INT_IP=$(ip -f inet addr show "$INT" | awk '/inet / {print $2}')
-INT_BRD=$(ip -f inet addr show "$INT" | awk '/inet / {print $4}')
+INT_BRD=$(ip -f inet addr show "$INT" | awk '/inet / {if ($3 == "brd") print $4}')
 
 echo "Found default container interface, will use this in setup:"
 echo "Interface: $INT"
@@ -50,10 +50,14 @@ ip -n physical link add wg0 type wireguard
 ip -n physical link set wg0 netns 1
 
 # Restore IP and route configuration for the default interface, start it
-ip -n physical addr add "$INT_IP" dev "$INT" brd "$INT_BRD"
+if [ -n "$INT_BRD" ]; then
+  ip -n physical addr add "$INT_IP" dev "$INT" brd "$INT_BRD"
+else
+  ip -n physical addr add "$INT_IP" dev "$INT"
+fi
 ip -n physical link set "$INT" up
 #ip -n physical link set lo up
-ip -n physical route add default via "$GW" dev "$INT"
+ip -n physical route add default via "$GW" dev "$INT" onlink
 
 #
 # Setting up Wireguard

--- a/start.sh
+++ b/start.sh
@@ -58,7 +58,10 @@ else
 fi
 ip -n physical link set "$INT" up
 #ip -n physical link set lo up
-ip -n physical route add default via "$GW" dev "$INT" onlink
+if ! ip -n physical route add default via "$GW" dev "$INT"; then
+  echo "Default route via $GW was not accepted as on-link, retrying with onlink"
+  ip -n physical route add default via "$GW" dev "$INT" onlink
+fi
 
 #
 # Setting up Wireguard

--- a/start.sh
+++ b/start.sh
@@ -21,6 +21,7 @@ fi
 GW=$(/sbin/ip route list match 0.0.0.0 | awk '{print $3}')
 INT=$(/sbin/ip route list match 0.0.0.0 | awk '{print $5}')
 INT_IP=$(ip -f inet addr show "$INT" | awk '/inet / {print $2}')
+# Broadcast may be absent (e.g. /32). Only pass brd when `ip addr` showed one, we want to mirror the original
 INT_BRD=$(ip -f inet addr show "$INT" | awk '/inet / {if ($3 == "brd") print $4}')
 
 echo "Found default container interface, will use this in setup:"


### PR DESCRIPTION
K8S assigns pods a /32 address rather than a subnet address,
which requires two changes:

* a /32 has no broadcast address, so `ip addr show`
omits the `brd` field. Fixed to check for it and act accordingly

* with a /32 the gateway is not within the pod's subnet, so
the kernel rejects a normal `ip route add default via <gw>`. Adding
`onlink` treats gateway as directly reachable and fixes that