### PR TITLE
Add optional Privoxy HTTP proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y \
     tzdata dnsutils iputils-ping ufw iproute2 \
     openssh-client git jq curl wget unrar unzip bc \
     # New for this image
-    wireguard nginx \
+    wireguard nginx libnginx-mod-stream privoxy gettext-base \
     # End new for this image
     && rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/* \
     && useradd -u 911 -U -d /config -s /bin/false abc \
@@ -46,6 +46,8 @@ ADD start.sh /opt/wireguard/start.sh
 ADD get-config-value.py /opt/wireguard/get-config-value.py
 ADD strip-wg-config.py /opt/wireguard/strip-wg-config.py
 ADD nginx_server.conf /opt/nginx/server.conf
+ADD nginx_templates /opt/nginx/templates
+RUN mkdir -p /opt/nginx/main.d /opt/nginx/stream.d
 ADD transmission-default-settings.json /opt/transmission/default-settings.json
 ADD updateSettings.py /opt/transmission/
 ADD userSetup.sh /opt/transmission/
@@ -56,10 +58,18 @@ ENV TRANSMISSION_HOME=/config/transmission-home \
     TRANSMISSION_INCOMPLETE_DIR=/data/incomplete \
     TRANSMISSION_WATCH_DIR=/data/watch \
     GLOBAL_APPLY_PERMISSIONS=true \
-    TRANSMISSION_UMASK=2
+    TRANSMISSION_UMASK=2 \
+    WEBPROXY_ENABLED=false \
+    WEBPROXY_PORT=8118 \
+    WEBPROXY_BIND_ADDRESS=
 
 # Get base_revision passed as a build argument and set it as env var
 ARG REVISION
 ENV REVISION=${REVISION:-""}
+
+# Transmission RPC
+EXPOSE 9091
+# Privoxy web proxy
+EXPOSE 8118
 
 CMD ["dumb-init", "/opt/wireguard/start.sh"]

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ services:
     environment:
       - PUID=1000
       - PGID=1000
+      - WEBPROXY_ENABLED=true # only if you need the bundled proxy
       - CONFIG_FILE=/wg-config/my_wg.conf  # A config file within your wireguard config mount
     logging:
       driver: json-file

--- a/nginx_server.conf
+++ b/nginx_server.conf
@@ -1,3 +1,5 @@
+include /opt/nginx/main.d/*.conf;
+
 events {
   worker_connections 1024;
 }
@@ -23,3 +25,5 @@ http {
     }
   }
 }
+
+include /opt/nginx/stream.d/*.conf;

--- a/nginx_templates/stream.conf
+++ b/nginx_templates/stream.conf
@@ -1,0 +1,6 @@
+stream {
+  server {
+    listen ${WEBPROXY_PORT};
+    proxy_pass 10.10.13.36:${WEBPROXY_PORT};
+  }
+}

--- a/nginx_templates/stream_module.conf
+++ b/nginx_templates/stream_module.conf
@@ -1,0 +1,1 @@
+load_module /usr/lib/nginx/modules/ngx_stream_module.so;

--- a/start.sh
+++ b/start.sh
@@ -93,6 +93,24 @@ ip -n physical addr add 10.10.13.37/31 dev veth2
 ip link set veth1 up
 ip -n physical link set veth2 up
 
+if [[ "${WEBPROXY_ENABLED,,}" == "true" ]]; then
+  WEBPROXY_PORT="${WEBPROXY_PORT:-8118}"
+  WEBPROXY_BIND_ADDRESS="${WEBPROXY_BIND_ADDRESS:-0.0.0.0}"
+
+  echo "Starting web proxy (Privoxy) on ${WEBPROXY_BIND_ADDRESS}:${WEBPROXY_PORT}"
+
+  # Remove all listen-address lines and add exactly one with the correct address/port
+  sed -i '/^listen-address /d' /etc/privoxy/config
+  echo "listen-address ${WEBPROXY_BIND_ADDRESS}:${WEBPROXY_PORT}" >> /etc/privoxy/config
+
+  # Start Privoxy in the current (wg0) namespace so traffic routes through WireGuard
+  privoxy /etc/privoxy/config
+
+  # Activate the stream module and proxy stream block via nginx include dirs
+  cp /opt/nginx/templates/stream_module.conf /opt/nginx/main.d/stream_module.conf
+  envsubst '${WEBPROXY_PORT}' < /opt/nginx/templates/stream.conf > /opt/nginx/stream.d/stream.conf
+fi
+
 # Start a reverse proxy in the physical namespace
 ip netns exec physical nginx -c /opt/nginx/server.conf
 


### PR DESCRIPTION
Installs Privoxy and the nginx stream module, and wires them into the
existing namespace setup so proxy traffic is routed through WireGuard.

Architecture:
- Privoxy runs in the wg0 (default) namespace, so all its traffic exits
  via the WireGuard tunnel.
- nginx in the physical namespace gains a TCP stream block that forwards
  the external-facing port to Privoxy over the veth pair.
- The nginx config is templated (although it's a big word) dynamically, so the stream block can be conditionally
  included.


This is a rather bare-bones implementation and does not allow to configure much, but should serve as a good starting point.

Tested and confirmed working in a K8S deployment, should work fine with just Docker